### PR TITLE
Add hex values for ease of use to gen 1 ft86 CAN data

### DIFF
--- a/can_db/ft86.md
+++ b/can_db/ft86.md
@@ -21,14 +21,14 @@ for most people:
 
 Channel name | CAN ID | Equation | Notes
 ------------ | --- | -------- | -----
-Accelerator position (%) | 320 | `A/2.55` |
-Brake position (%) | 209 | `min(C / 0.7, 100)` | The 0.7 divider seems to be a good value to get 100% at pressure slightly higher than those you're likely to use on the track for cars with no aero. You can use 0.8 or 0.9 if you see 100% too often.
-Brake pressure | 209 | `C * 128` |
-Coolant temperature | 864 | `D - 40` |
-Engine RPM | 320 | `bitsToUIntLe(raw, 16, 14)` |
-Engine oil temperature | 864 | `C - 40` |
-Speed | 209 | `bytesToIntLe(raw, 0, 2) * 0.015694` | May want to check the multiplier against an external GPS aevice
-Steering angle | 208 | `bytesToIntLe(raw, 0, 2) * -0.1` | Positive value = turning left. You can remove the `-` if you prefer it the other way around.
+Accelerator position (%) | 320 (0x140) | `A/2.55` |
+Brake position (%) | 209 (0xD1) | `min(C / 0.7, 100)` | The 0.7 divider seems to be a good value to get 100% at pressure slightly higher than those you're likely to use on the track for cars with no aero. You can use 0.8 or 0.9 if you see 100% too often.
+Brake pressure | 209 (0xD1) | `C * 128` |
+Coolant temperature | 864 (0x360) | `D - 40` |
+Engine RPM | 320 (0x140) | `bitsToUIntLe(raw, 16, 14)` |
+Engine oil temperature | 864 (0x360) | `C - 40` |
+Speed | 209 (0xD1) | `bytesToIntLe(raw, 0, 2) * 0.015694` | May want to check the multiplier against an external GPS aevice
+Steering angle | 208 (0xD0) | `bytesToIntLe(raw, 0, 2) * -0.1` | Positive value = turning left. You can remove the `-` if you prefer it the other way around.
 
 ### Advanced CAN IDs
 
@@ -46,17 +46,17 @@ channels.
 
 Channel name | CAN ID | Equation | Notes
 ------------ | --- | -------- | -----
-Clutch position | 320 | `B & 0x80 / 1.28` | Only 0% and "not 0%", unfortunately.
-Gear | 321 | `(G & 0xf) * (1 - (min(G & 0xf, 7)) / 7)` | Car calculates it based on speed, RPM and clutch position. It's pretty slow. I really doubt it's worth wasting one CAN ID for this channel. It's not that hard to see which gear you're in based on speed and RPM in data.
-Lateral acceleration | 208 | `bytesToIntLe(raw, 6, 1) * 0.2` | Data is noisy.
-Longitudinal acceleration | 208 | `bytesToIntLe(raw, 7, 1) * -0.1` | Data is noisy.
-Combined acceleration | 208 | `sqrt(pow2(bytesToIntLe(raw, 6, 1) * 0.2) + pow2(bytesToIntLe(raw, 7, 1) * 0.1))` |
-Throttle position | 320 | `G / 2.55` | This is the throttle *valve*, not pedal.
-Wheel speed FL | 212 | `bytesToIntLe(raw, 0, 2) * 0.015694` | Use same multiplier as for "Speed".
-Wheel speed FR | 212 | `bytesToIntLe(raw, 2, 2) * 0.015694` | Use same multiplier as for "Speed".
-Wheel speed RL | 212 | `bytesToIntLe(raw, 4, 2) * 0.015694` | Use same multiplier as for "Speed".
-Wheel speed RR | 212 | `bytesToIntLe(raw, 6, 2) * 0.015694` | Use same multiplier as for "Speed".
-Yaw rate | 208 | `bytesToIntLe(raw, 2, 2) * -0.286478897` |
+Clutch position | 320 (0x140) | `B & 0x80 / 1.28` | Only 0% and "not 0%", unfortunately.
+Gear | 321 (0x141) | `(G & 0xf) * (1 - (min(G & 0xf, 7)) / 7)` | Car calculates it based on speed, RPM and clutch position. It's pretty slow. I really doubt it's worth wasting one CAN ID for this channel. It's not that hard to see which gear you're in based on speed and RPM in data.
+Lateral acceleration | 208 (0xD0) | `bytesToIntLe(raw, 6, 1) * 0.2` | Data is noisy.
+Longitudinal acceleration | 208 (0xD0) | `bytesToIntLe(raw, 7, 1) * -0.1` | Data is noisy.
+Combined acceleration | 208 (0xD0) | `sqrt(pow2(bytesToIntLe(raw, 6, 1) * 0.2) + pow2(bytesToIntLe(raw, 7, 1) * 0.1))` |
+Throttle position | 320 (0x140) | `G / 2.55` | This is the throttle *valve*, not pedal.
+Wheel speed FL | 212 (0xD4) | `bytesToIntLe(raw, 0, 2) * 0.015694` | Use same multiplier as for "Speed".
+Wheel speed FR | 212 (0xD4) | `bytesToIntLe(raw, 2, 2) * 0.015694` | Use same multiplier as for "Speed".
+Wheel speed RL | 212 (0xD4) | `bytesToIntLe(raw, 4, 2) * 0.015694` | Use same multiplier as for "Speed".
+Wheel speed RR | 212 (0xD4) | `bytesToIntLe(raw, 6, 2) * 0.015694` | Use same multiplier as for "Speed".
+Yaw rate | 208 (0xD0) | `bytesToIntLe(raw, 2, 2) * -0.286478897` |
 
 ---
 


### PR DESCRIPTION
Add hex addresses in parentheses for ease of use.